### PR TITLE
Minor fixes

### DIFF
--- a/flycheck-inline.el
+++ b/flycheck-inline.el
@@ -1,4 +1,4 @@
-;;; flycheck-inline.el --- Display flycheck error message with inline popup style.
+;;; flycheck-inline.el --- Display flycheck error messages with inline popup style.
 
 ;; Authors: stardiviner <numbchild@gmail.com>
 ;; Package-Requires: ((emacs "24.4") (cl-lib "0.3") (inline-docs "1.0.1") (flycheck "31-cvs"))
@@ -12,8 +12,8 @@
 ;;; Commentary:
 
 ;;; Usage:
-;; - You can toggle it with minor mode.
-;;   (add-hook 'MODE-hook #'flycheck-inline-mode)
+;; - You can enable it for specific modes with:
+;;   (add-hook 'MODE-hook #'flycheck-inline-enable)
 ;; - Or you can manually set option `flycheck-display-errors-function' to function `flycheck-inline'.
 
 ;;; Code:
@@ -29,16 +29,12 @@
         (let ((message (mapconcat #'flycheck-error-format-message-and-id
                                   errors "\n\n")))
           (inline-docs message))
-      (funcall 'flycheck-display-error-messages)))
-  )
+      (funcall 'flycheck-display-error-messages))))
 
 ;;;###autoload
-(defun flycheck-inline-toggle ()
-  "Toggle flycheck inline popup style display."
-  (if (eq 'flycheck-inline-error-messages flycheck-display-errors-function)
-      (setq-local flycheck-display-errors-function 'flycheck-inline-error-messages)
-    (setq-local flycheck-display-errors-function 'flycheck-display-error-messages)
-    ))
+(defun flycheck-inline-enable ()
+  "Enable flycheck inline popup style display."
+  (setq-local flycheck-display-errors-function 'flycheck-inline-error-messages))
 
 ;;; ----------------------------------------------------------------------------
 


### PR DESCRIPTION
- Update docstrings
- Don't try to toggle, because we can't reliably restore the old `flycheck-display-errors-function`

In connection with https://github.com/melpa/melpa/pull/4769
