### PR TITLE
Update readme use-package instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you use `use-package`.
 ```elisp
 (use-package flycheck-inline
   :ensure t
-  :config
-  (flycheck-inline-enable))
+  :defer t
+  :init
+  (add-hook 'flycheck-mode-hook 'flycheck-inline-enable))
 ```


### PR DESCRIPTION
It seems like `flycheck-inline-enable` should be called in every buffer using flycheck, this does that.